### PR TITLE
:recycle: make getting api_key more flexible

### DIFF
--- a/dewrangle/query_functions.py
+++ b/dewrangle/query_functions.py
@@ -990,7 +990,7 @@ def create_gql_client(endpoint=None, api_key=None):
         endpoint = "https://dewrangle.com/api/graphql"
 
     if api_key:
-        req_header = {"X-Api-Key": get_api_credential()}
+        req_header = {"X-Api-Key": api_key}
     else:
         req_header = {"X-Api-Key": get_api_credential()}
 

--- a/dewrangle/query_functions.py
+++ b/dewrangle/query_functions.py
@@ -982,14 +982,17 @@ def download_job_result(jobid, client=None):
     return job_status, job_result
 
 
-def create_gql_client(endpoint=None):
+def create_gql_client(endpoint=None, api_key=None):
     """Create GraphQL client connection"""
 
     # default endpoint
     if endpoint is None:
         endpoint = "https://dewrangle.com/api/graphql"
 
-    req_header = {"X-Api-Key": get_api_credential()}
+    if api_key:
+        req_header = {"X-Api-Key": get_api_credential()}
+    else:
+        req_header = {"X-Api-Key": get_api_credential()}
 
     transport = AIOHTTPTransport(
         url=endpoint,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "dewrangle-python"
+name = "dewrangle"
 version = "1.0.0"
 authors = [
   { name="Alex Sickler", email="sicklera@chop.edu" },


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Really quick PR letting you send the api_key to the create_gql_client function without using the file in your home directory. This will be used with the planned lambdas and let you use it locally.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] I have committed any related changes to the PR
